### PR TITLE
Stick to ASCII

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-these",
-  "description": "Data type isomorphic to: α ∨ β ∨ (α ∧ β)",
+  "description": "Data type isomorphic to: a OR b OR (a AND b)",
   "license": "MIT",
   "dependencies": {
     "purescript-foldable-traversable": "^0.4.0",


### PR DESCRIPTION
Strictly speaking this shouldn't be necessary, but the Unicode characters are causing problems with `psc-publish` (purescript/purescript#1550). Until that gets sorted out, it's pretty easy to stick to ASCII in the Bower description.

This is a follow-up to #7. 
