### PR TITLE
Add repository field for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,10 @@
   "name": "purescript-these",
   "description": "Data type isomorphic to: α ∨ β ∨ (α ∧ β)",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/purescript-contrib/purescript-these.git"
+  },
   "dependencies": {
     "purescript-foldable-traversable": "^0.4.0",
     "purescript-tuples": "^0.4.0"


### PR DESCRIPTION
This allows `purescript-these` to be published on Pursuit.
