### PR TITLE
Remove unused import

### DIFF
--- a/src/Data/These.purs
+++ b/src/Data/These.purs
@@ -5,7 +5,6 @@ import Data.Bifunctor
 import Data.Bitraversable
 import Data.Foldable
 import Data.Maybe
-import Data.Monoid
 import Data.Traversable
 import Data.Tuple
 


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.
