### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#40 by @thomashoneyman)
 
 ## [v5.0.0](https://github.com/purescript-contrib/purescript-these/releases/tag/v5.0.0) - 2021-02-26
 

--- a/src/Data/Align.purs
+++ b/src/Data/Align.purs
@@ -32,9 +32,9 @@ instance alignArray :: Align Array where
   align f [] ys = f <<< That <$> ys
   align f xs ys = A.zipWith f' xs ys <> align f xs' ys'
     where
-      f' x y = f (Both x y)
-      xs' = A.drop (A.length ys) xs
-      ys' = A.drop (A.length xs) ys
+    f' x y = f (Both x y)
+    xs' = A.drop (A.length ys) xs
+    ys' = A.drop (A.length xs) ys
 
 instance alignList :: Align List.List where
   align f xs List.Nil = f <<< This <$> xs
@@ -44,10 +44,10 @@ instance alignList :: Align List.List where
 instance alignLazyList :: Align LazyList.List where
   align f xs ys = LazyList.List $ go <$> unwrap xs <*> unwrap ys
     where
-      go LazyList.Nil LazyList.Nil = LazyList.Nil
-      go (LazyList.Cons x xs') LazyList.Nil = f (This x) `LazyList.Cons` align f xs' mempty
-      go LazyList.Nil (LazyList.Cons y ys') = f (That y) `LazyList.Cons` align f mempty ys'
-      go (LazyList.Cons x xs') (LazyList.Cons y ys') = f (Both x y) `LazyList.Cons` align f xs' ys'
+    go LazyList.Nil LazyList.Nil = LazyList.Nil
+    go (LazyList.Cons x xs') LazyList.Nil = f (This x) `LazyList.Cons` align f xs' mempty
+    go LazyList.Nil (LazyList.Cons y ys') = f (That y) `LazyList.Cons` align f mempty ys'
+    go (LazyList.Cons x xs') (LazyList.Cons y ys') = f (Both x y) `LazyList.Cons` align f xs' ys'
 
 instance alignMaybe :: Align Maybe where
   align f ma Nothing = f <<< This <$> ma
@@ -113,34 +113,34 @@ class (Foldable f, Functor f) <= Crosswalk f where
 
 instance crosswalkThese :: Crosswalk (These a) where
   crosswalk f = case _ of
-    This _   -> nil
-    That x   -> That <$> f x
+    This _ -> nil
+    That x -> That <$> f x
     Both a x -> Both a <$> f x
 
 instance crosswalkArray :: Crosswalk Array where
   crosswalk f xs = case A.uncons xs of
-    Nothing             -> nil
+    Nothing -> nil
     Just { head, tail } -> align cons (f head) (crosswalk f tail)
     where
-      cons = these pure identity A.cons
+    cons = these pure identity A.cons
 
 instance crosswalkList :: Crosswalk List.List where
   crosswalk f = case _ of
-    List.Nil       -> nil
+    List.Nil -> nil
     List.Cons x xs -> align cons (f x) (crosswalk f xs)
     where
-      cons = these pure identity List.Cons
+    cons = these pure identity List.Cons
 
 instance crosswalkLazyList :: Crosswalk LazyList.List where
   crosswalk f l =
     case LazyList.step l of
-      LazyList.Nil       -> nil
+      LazyList.Nil -> nil
       LazyList.Cons x xs -> align cons (f x) (crosswalk f xs)
     where
-      cons = these pure identity LazyList.cons
+    cons = these pure identity LazyList.cons
 
 instance crosswalkMaybe :: Crosswalk Maybe where
   crosswalk f = case _ of
     Nothing -> nil
-    Just a  -> Just <$> f a
+    Just a -> Just <$> f a
 

--- a/src/Data/These.purs
+++ b/src/Data/These.purs
@@ -182,11 +182,11 @@ swap = these That This (flip Both)
 -- | Re-associate `These` from left to right.
 assoc :: forall a b c. These (These a b) c -> These a (These b c)
 assoc = case _ of
-  This (This a)     -> This a
-  This (That b)     -> That (This b)
-  This (Both a b)   -> Both a (This b)
-  That c            -> That (That c)
-  Both (This a) c   -> Both a (That c)
-  Both (That b) c   -> That (Both b c)
+  This (This a) -> This a
+  This (That b) -> That (This b)
+  This (Both a b) -> Both a (This b)
+  That c -> That (That c)
+  Both (This a) c -> Both a (That c)
+  Both (That b) c -> That (Both b c)
   Both (Both a b) c -> Both a (Both b c)
 

--- a/src/Data/These/Gen.purs
+++ b/src/Data/These/Gen.purs
@@ -7,5 +7,5 @@ import Control.Monad.Gen.Common (genMaybe)
 import Control.Monad.Rec.Class (class MonadRec)
 import Data.These (These, maybeThese)
 
-genThese ∷ forall m a b. MonadGen m => MonadRec m => m a -> m b -> m (These a b)
+genThese :: forall m a b. MonadGen m => MonadRec m => m a -> m b -> m (These a b)
 genThese ga gb = filtered (maybeThese <$> genMaybe ga <*> genMaybe gb)

--- a/src/Test/QuickCheck/Laws/Control/Align.purs
+++ b/src/Test/QuickCheck/Laws/Control/Align.purs
@@ -54,10 +54,10 @@ checkAlign _ = do
 
   associativity :: f A -> f B -> f C -> Boolean
   associativity fa fb fc =
-      align identity fa (align identity fb fc) ==
-        (assoc <$> align identity (align identity fa fb) fc)
+    align identity fa (align identity fb fc) ==
+      (assoc <$> align identity (align identity fa fb) fc)
 
   functoriality :: f A -> f B -> (A -> C) -> (B -> D) -> Boolean
   functoriality a b f g =
-      align identity (f <$> a) (g <$> b) ==
-        (bimap f g <$> align identity a b)
+    align identity (f <$> a) (g <$> b) ==
+      (bimap f g <$> align identity a b)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -15,13 +15,13 @@ import Test.QuickCheck.Laws.Control.Crosswalk (checkCrosswalk)
 import Type.Proxy (Proxy2(..))
 
 runCrosswalkChecksFor
-    :: forall f
-    .  Crosswalk f
-    => Arbitrary (f A)
-    => Eq (f A)
-    => Proxy2 f
-    -> String
-    -> Effect Unit
+  :: forall f
+   . Crosswalk f
+  => Arbitrary (f A)
+  => Eq (f A)
+  => Proxy2 f
+  -> String
+  -> Effect Unit
 runCrosswalkChecksFor p name = do
   log $ "Check Crosswalk instance for " <> name <> "/Array"
   checkCrosswalk p (Proxy2 :: _ Array)
@@ -48,4 +48,4 @@ main = do
 
   runCrosswalkChecksFor (Proxy2 :: _ Array) "Array"
   runCrosswalkChecksFor (Proxy2 :: _ Maybe) "Maybe"
-  runCrosswalkChecksFor (Proxy2 :: _ List)  "List"
+  runCrosswalkChecksFor (Proxy2 :: _ List) "List"


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
